### PR TITLE
DBpedia-Spotlight API "fix"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ code/app/utils/__pycache__/build_RDF_triples.cpython-38.pyc
 code/app/utils/__pycache__/preprocess_sentences.cpython-38.pyc
 code/app/utils/__pycache__/process_triples.cpython-38.pyc
 code/app/utils/__pycache__/triples_extraction.cpython-38.pyc
+spotlight/en.tar.gz.md5
+spotlight/dbpedia-spotlight-services-1.0.0.jar

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ docker run -p 8501:8501 pablohdez98/dbpedia-abstracts-to-rdf:latest  # To run th
 ```
 After that, open [localhost:8501][12] and you will see the web application.
 
+### ⚠️ Note on DBpedia Spotlight Online API
+The SSL certificate for the DBpedia Spotlight online API is currently expired.
+The current Docker image does not include a fix for this.
+To work around it, you must manually edit the function get_annotated_text_dict(...) in code/utils/build_RDF_triples.py, and add the following parameter to the requests.get(...) call:
+```
+verify=False
+```
+✅ Example fix:
+```
+resp = requests.get(service_url, params=parameters, headers=headerinfo, verify=False)
+```
+This disables SSL verification. Alternatively, we recommend running a local Spotlight instance via Docker, which avoids the SSL problem entirely.
 ## Future work (what is left to do after GSoC)
 The main problem of the pipeline right now is that of all the triples it can generate, only half of them are free of errors in their structure. This kind of errors occur when the pipeline is unable to find a valid lexicalization for the predicate (verb+preposition) or for the object, leaving these elements as Literals instead of as resources or properties.
 When we mention lexicalization we refer to the translation of text to URIs using tables for [properties][4] and [DBpedia classes][5].

--- a/code/app/app.py
+++ b/code/app/app.py
@@ -24,7 +24,7 @@ PROP_LEXICALIZATION_TABLE = "datasets/verb_prep_property_lookup.json"
 CLA_LEXICALIZATION_TABLE = "datasets/classes_lookup.json"
 OUTPUT_FOLDER = "code/app/output/"
 SPOTLIGHT_ONLINE_API = "https://api.dbpedia-spotlight.org/en/annotate"
-SPOTLIGHT_LOCAL_URL = "http://localhost:2222/rest/annotate/"
+SPOTLIGHT_LOCAL_URL = "http://localhost:2222/rest/annotate"
 
 
 def pipeline(nlp, raw_text, dbo_graph ,prop_lex_table, cla_lex_table):
@@ -64,7 +64,7 @@ def pipeline(nlp, raw_text, dbo_graph ,prop_lex_table, cla_lex_table):
     triples = pt.split_amod_conjunctions_obj(nlp, triples)
 
     try:
-        term_URI_dict, term_types_dict = brt.get_annotated_text_dict(raw_text, service_url=SPOTLIGHT_LOCAL_URL)
+        term_URI_dict, term_types_dict = brt.get_annotated_text_dict(raw_text, service_url=SPOTLIGHT_ONLINE_API)
     except:
         return [], [], n_sent_spacy, n_sent_simples
     rdf_triples = brt.replace_text_URI(triples, term_URI_dict, term_types_dict, prop_lex_table, cla_lex_table, dbo_graph)

--- a/code/webapp/utils/build_RDF_triples.py
+++ b/code/webapp/utils/build_RDF_triples.py
@@ -25,14 +25,14 @@ def get_annotated_text_dict(text, service_url=SPOTLIGHT_ONLINE_API, confidence=0
     term_URI_dict = {}
     term_types_dict = {}
     try:
-        resp = requests.get(service_url, params=parameters, headers=headerinfo)
+        resp = requests.get(service_url, params=parameters, headers=headerinfo, verify=False)
     except:
         if service_url == SPOTLIGHT_ONLINE_API:
             print("Error at dbpedia spotlight api")
             return None
         try:
             print("Error at local dbpedia spotlight, trying with the api one")
-            resp = requests.get(SPOTLIGHT_ONLINE_API, params=parameters, headers=headerinfo)
+            resp = requests.get(SPOTLIGHT_ONLINE_API, params=parameters, headers=headerinfo, verify=False)
         except:
             print("Error at dbpedia spotlight api")
             return None

--- a/spotlight/en.tar.gz.md5
+++ b/spotlight/en.tar.gz.md5
@@ -1,0 +1,1 @@
+3df6a29bfb6b6f6c657650b9a09d0e62  en.tar.gz

--- a/spotlight/run_dbospot_jar_en.sh
+++ b/spotlight/run_dbospot_jar_en.sh
@@ -1,1 +1,1 @@
-java -jar dbpedia-spotlight-1.0.0.jar en http://localhost:2222/rest
+java -jar dbpedia-spotlight-services-1.0.0.jar en http://localhost:2222/rest


### PR DESCRIPTION
DBpedia-Spotlight SSL certificates are out of date. Needed to add "validation=false" to DBpediaspotlight requests.

Also added documentation to fix it in the docker image.